### PR TITLE
noconfirm for pacman

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -26,8 +26,8 @@ case $distro in
         ;;
     '"Arch Linux"' | '"ArcoLinuxD"' | '"Manjaro Linux"')
         printf "\\n\\e[36mInstalling any missing dependencies...\\n\\e[94m"
-        pacman -Syu
-        pacman -S curl ffmpeg rsync
+        yes | LC_ALL=en_US.UTF-8 pacman -Syu
+        yes | LC_ALL=en_US.UTF-8 pacman -S curl ffmpeg rsync
         ;;
     '"CentOS Linux"')
         printf "\\n\\e[36mInstalling any missing dependencies...\\n\\e[94m"

--- a/plexus
+++ b/plexus
@@ -36,7 +36,7 @@ case $distro in
         packages="apk"
         ;;
     '"Arch Linux"' | '"ArcoLinuxD"' | '"Manjaro Linux"')
-        packages="pacman"
+        packages="yes | LC_ALL=en_US.UTF-8 pacman"
         ;;
     '"CentOS Linux"')
         packages="yum -q -y"


### PR DESCRIPTION
I haven't tested my code last time :/

without `yes | LC_ALL=en_US.UTF-8` pacman prompts user with `Proceed with installation? [Y/n]` and immediately exits from the script. Now it works and doesn't require any user interaction. 

It also works if user has set different locale to English.